### PR TITLE
New project wizard package description is cut

### DIFF
--- a/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/wizards/templates/NewProjectPage.java
+++ b/android-core/plugins/org.eclipse.andmore/src/org/eclipse/andmore/internal/wizards/templates/NewProjectPage.java
@@ -328,8 +328,8 @@ public class NewProjectPage extends WizardPage
         mTipLabel = new Label(container, SWT.WRAP);
         mTipLabel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 3, 1));
 
-        // Reserve space for 4 lines
-        mTipLabel.setText("\n\n\n\n"); //$NON-NLS-1$
+        // Reserve space for 6 lines
+        mTipLabel.setText("\n\n\n\n\n\n"); //$NON-NLS-1$
 
         // Reserve enough width to accommodate the various wizard pages up front
         // (since they are created lazily, and we don't want the wizard to dynamically


### PR DESCRIPTION
At least on my standard Ubuntu/GTK installation, one line from the
package edit text help text is missing. Therefore give it some more
space.